### PR TITLE
Dart Sass compatibility fixes for u-container-items-spacing mixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-sass-utilities",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Provides some common SASS functions, mixins, and classes for faster frontend development.",
   "keywords": [
     "sass",

--- a/utilities/mixins/_u-container-items-spacing.scss
+++ b/utilities/mixins/_u-container-items-spacing.scss
@@ -1,10 +1,12 @@
+@use 'sass:math';
+
 @mixin u-container-items-spacing($item, $spacing-x, $spacing-y: null) {
   /* stylelint-disable declaration-block-no-redundant-longhand-properties */
 
-  margin-left: math.div(-$spacing-x, 2); 
-  margin-right: math.div(-$spacing-x, 2); 
-  margin-top: if($spacing-y, math.div(-$spacing-y, 2), null); 
-  margin-bottom: if($spacing-y, math.div(-$spacing-y, 2), null); 
+  margin-left: math.div(-$spacing-x, 2);
+  margin-right: math.div(-$spacing-x, 2);
+  margin-top: if($spacing-y, math.div(-$spacing-y, 2), null);
+  margin-bottom: if($spacing-y, math.div(-$spacing-y, 2), null);
 
   @at-root {
     @if type-of($item) == 'map' {
@@ -12,20 +14,20 @@
       $item-selectors: $item;
       @each $item-key, $item-selector in $item-selectors {
         #{$item-selector} {
-          padding-left: $spacing-x / 2; 
-          padding-right: $spacing-x / 2; 
-          padding-top: if($spacing-y, $spacing-y / 2, null); 
-          padding-bottom: if($spacing-y, $spacing-y / 2, null); 
+          padding-left: math.div($spacing-x, 2);
+          padding-right: math.div($spacing-x, 2);
+          padding-top: if($spacing-y, math.div($spacing-y, 2), null);
+          padding-bottom: if($spacing-y, math.div($spacing-y, 2), null);
         }
       }
     } @else {
       // if not map (not wrapped in ()), we accept $item as one selector
       $item-selector: $item;
       #{$item-selector} {
-        padding-left: $spacing-x / 2; 
-        padding-right: $spacing-x / 2; 
-        padding-top: if($spacing-y, $spacing-y / 2, null); 
-        padding-bottom: if($spacing-y, $spacing-y / 2, null); 
+        padding-left: math.div($spacing-x, 2);
+        padding-right: math.div($spacing-x, 2);
+        padding-top: if($spacing-y, math.div($spacing-y, 2), null);
+        padding-bottom: if($spacing-y, math.div($spacing-y, 2), null);
       }
     }
   }

--- a/utilities/mixins/_u-container-items-spacing.scss
+++ b/utilities/mixins/_u-container-items-spacing.scss
@@ -1,10 +1,10 @@
 @mixin u-container-items-spacing($item, $spacing-x, $spacing-y: null) {
   /* stylelint-disable declaration-block-no-redundant-longhand-properties */
 
-  margin-left: -$spacing-x / 2; 
-  margin-right: -$spacing-x / 2; 
-  margin-top: if($spacing-y, -$spacing-y / 2, null); 
-  margin-bottom: if($spacing-y, -$spacing-y / 2, null); 
+  margin-left: math.div(-$spacing-x, 2); 
+  margin-right: math.div(-$spacing-x, 2); 
+  margin-top: if($spacing-y, math.div(-$spacing-y, 2), null); 
+  margin-bottom: if($spacing-y, math.div(-$spacing-y, 2), null); 
 
   @at-root {
     @if type-of($item) == 'map' {


### PR DESCRIPTION
Gets rid of `Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0` complaints when used with Dart Sass.